### PR TITLE
Offline-data

### DIFF
--- a/src/components/map-components/BaseLayerSource.tsx
+++ b/src/components/map-components/BaseLayerSource.tsx
@@ -1,36 +1,60 @@
 import { useEffect, useState } from "react";
 import { Layer, Source } from "react-map-gl";
 import { useLayers } from "../../context/layers";
+import { useOffline } from "../../context/offline";
 import * as wms from '../../util/wms';
 
 const BaseLayerSource: React.FC = () => {
     const [activeLayers, setActiveLayers] = useState<string[]>([])
 
+    // create 
+
     // subscribe to layers
     const {availableBaseLayer, activeBaseLayer, activeInventoryLayer} = useLayers()
 
+    // load offline context
+    const { status, baselayers } = useOffline()
+
     useEffect(() => {
         setActiveLayers([...activeBaseLayer])
-        console.log(activeBaseLayer)
+//        console.log(activeBaseLayer)
     }, [activeBaseLayer])
 
     //console.log(layers.availableBaseLayer)
     
-    return <>
-        {availableBaseLayer.map(l => (
-            <Source key={l.name} id={l.name} type={l.name === 'dtm' ? 'raster-dem' : 'raster'} 
-                tiles={[wms.getBaseLayersUri('http://geowwd.uni-freiburg.de/geoserver', l.name)]} tileSize={256}
-            >
-                <Layer 
-                    id={l.name} 
-                    type={l.name === 'dtm' ? 'hillshade' : 'raster'} 
-                    source={l.name}  
-                    paint={{}} 
-                    // beforeId={activeInventoryLayer.length > 0 ? 'inventory' : undefined} 
-                    layout={{visibility: activeLayers.includes(l.name) ? 'visible' : 'none'}} />
-            </Source>
-        )) } 
-    </>
+    if (status === 'offline' || true) {
+        return <>
+            { baselayers?.map(l => (
+                <Source key={l.name} id={l.name} type='image' 
+                    url={`data:image/${l.opt.type};base64,${l.data}`} 
+                    coordinates={[[l.bbox.west, l.bbox.south], [l.bbox.east, l.bbox.south], [l.bbox.east, l.bbox.north], [l.bbox.west, l.bbox.north]]}
+                >
+                    <Layer id={l.name} type="raster" source={l.name} 
+                        paint={{"raster-fade-duration": 0}} 
+                        layout={{visibility: activeLayers.includes(l.name) ? 'visible': 'none'}} 
+                        beforeId="inventory"
+                    />
+                </Source>
+            )) }
+        </>
+    } else {
+        return <>
+            {availableBaseLayer.map(l => (
+                <Source key={l.name} id={l.name} type={l.name === 'dtm' ? 'raster-dem' : 'raster'} 
+                    tiles={[wms.getBaseLayersUri('http://geowwd.uni-freiburg.de/geoserver', l.name)]} tileSize={256}
+                >
+                    <Layer 
+                        id={l.name} 
+                        type={l.name === 'dtm' ? 'hillshade' : 'raster'} 
+                        source={l.name}  
+                        paint={{}} 
+                        // beforeId={activeInventoryLayer.length > 0 ? 'inventory' : undefined} 
+                        layout={{visibility: activeLayers.includes(l.name) ? 'visible' : 'none'}} />
+                </Source>
+            )) } 
+        </>
+    }
+    
 }
 
 export default BaseLayerSource;

--- a/src/context/layers.tsx
+++ b/src/context/layers.tsx
@@ -3,6 +3,7 @@ import { useSettings } from "./settings";
 
 import * as wfs from '../util/wfs';
 import * as wms from '../util/wms';
+import { useOffline } from "./offline";
 
 interface LayersState {
     availableInventoryLayer: wfs.FeatureType[];
@@ -66,6 +67,14 @@ export const LayersProvider: React.FC<React.PropsWithChildren> = ({ children }) 
     
     // load available layers
     const { geoserverUrl } = useSettings()
+    const { baselayers } = useOffline()
+
+    // listen to changes in the offline context
+    useEffect(() => {
+        if (baselayers) {
+            setAvailableBaseLayer(baselayers)
+        }
+    }, [baselayers])
 
     // listen to changes on the geoserverUrl
     // TODO, this needs to be replaced by the offline service
@@ -80,14 +89,6 @@ export const LayersProvider: React.FC<React.PropsWithChildren> = ({ children }) 
                 setActiveInventoryLayer([ iv.length > 0 ? iv[0].name : '' ])
             })
             //.catch(err => console.log(err))
-            
-            wms.getBaseLayers(geoserverUrl)
-            .then(bl => {
-                // console.log(bl)
-                setAvailableBaseLayer(bl)
-                setActiveBaseLayer([])
-            })
-            .catch(err => console.log(err))
         }
     }, [geoserverUrl])
 

--- a/src/util/wms.ts
+++ b/src/util/wms.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { XMLParser } from "fast-xml-parser";
+import { Buffer } from "buffer";
 
 export interface BBox {
   south: number;
@@ -97,7 +98,7 @@ export interface BaseLayerImgOpt {
   type?: string
 }
 
-export const getBaseLayersImg = async (baseUrl: string, layerName: string, bbox: BBox, opts: BaseLayerImgOpt ={}): Promise<void> => {
+export const getBaseLayersImg = async (baseUrl: string, layerName: string, bbox: BBox, opts: BaseLayerImgOpt ={}): Promise<string> => {
   // set the box
   const box = `${bbox.west},${bbox.south},${bbox.east},${bbox.north}`
   
@@ -107,7 +108,13 @@ export const getBaseLayersImg = async (baseUrl: string, layerName: string, bbox:
   // get base layer uri
   const uri = `${baseUrl}/Baselayer/wms?service=WMS&version=1.1.1&request=getMap&layers=Baselayer:${layerName}&bbox=${box}&srs=EPSG:32632&transparent=true&format=${mime}&${size}`
 
-  await axios.get(uri).then(val => console.log(val))
+  return new Promise((resolve, reject) => {
+    axios.get<string>(uri, {responseType: 'arraybuffer'}).then(response => {
+      // create the buffer
+      const buffer = Buffer.from(response.data, 'binary').toString('base64')
+      resolve(buffer)
+    }).catch(error => reject(error))
+  })
 
-  Promise.resolve()
+
 }

--- a/src/util/wms.ts
+++ b/src/util/wms.ts
@@ -17,6 +17,11 @@ export interface GroundLayerType {
   abstract?: string;
 }
 
+export interface BaseLayerData extends GroundLayerType {
+  data: string,
+  opt: {type: string, width?: number, height?: number}
+}
+
 interface GetCapabilitiesResponse {
   WMS_Capabilities: {
     Capability: {
@@ -103,10 +108,10 @@ export const getBaseLayersImg = async (baseUrl: string, layerName: string, bbox:
   const box = `${bbox.west},${bbox.south},${bbox.east},${bbox.north}`
   
   // set the other params
-  const mime = `image/${opts.type || 'jpeg'}`
+  const mime = `image/${opts.type || 'png'}`
   const size = `height=${opts.height || 256}&width=${opts.width || 256}`
   // get base layer uri
-  const uri = `${baseUrl}/Baselayer/wms?service=WMS&version=1.1.1&request=getMap&layers=Baselayer:${layerName}&bbox=${box}&srs=EPSG:32632&transparent=true&format=${mime}&${size}`
+  const uri = `${baseUrl}/Baselayer/wms?service=WMS&version=1.1.1&request=getMap&layers=Baselayer:${layerName}&transparent=true&bbox=${box}&srs=EPSG:4326&transparent=true&format=${mime}&${size}`
 
   return new Promise((resolve, reject) => {
     axios.get<string>(uri, {responseType: 'arraybuffer'}).then(response => {


### PR DESCRIPTION
@JesJehle This PR enables offline handling of baselayer images. by now, the data is downloaded and cached correctly, and the application is quite smooth with fairly detailed images.

Two issues are known: The baselayer images are a bit off, as they are transformed to epsg:4326 on download and are only referenced by their bounding box.
Second: The application lags on downloading the images, but has no visual indication, that it is loading yet.