### PR TITLE
Layer-actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "^5.0.0",
+        "rxjs": "^7.8.0",
         "typescript": "^4.1.3",
         "web-vitals": "^0.2.4",
         "workbox-background-sync": "^5.1.4",
@@ -15431,6 +15432,14 @@
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
+    "node_modules/rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -29849,6 +29858,14 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.0",
+    "rxjs": "^7.8.0",
     "typescript": "^4.1.3",
     "web-vitals": "^0.2.4",
     "workbox-background-sync": "^5.1.4",

--- a/src/components/DataLayerSelector.tsx
+++ b/src/components/DataLayerSelector.tsx
@@ -12,14 +12,10 @@ import {
   IonLabel,
   IonList,
   IonListHeader,
-  IonRadio,
-  IonRadioGroup,
-  IonRow,
-  IonSearchbar,
   IonText,
-  IonTitle,
+  IonToggle,
 } from "@ionic/react";
-import { closeCircle } from "ionicons/icons";
+import { scanOutline } from "ionicons/icons";
 import { useLayers } from "../context/layers";
 import FilterBar from "./FilterBar";
 
@@ -47,9 +43,12 @@ const DataLayerDrawer: React.FC = () => {
         {layers.availableInventoryLayer.map((l) => (
           <IonItem lines="none" key={l.name}>
             <IonLabel>{l.title}</IonLabel>
-            <IonCheckbox
+            <IonButton slot="start" fill="clear" disabled={!layers.activeInventoryLayer.includes(l.name)}>
+              <IonIcon icon={scanOutline} slot="icon-only" />
+            </IonButton>
+            <IonToggle
               key={l.name}
-              // slot="end"
+              slot="end"
               checked={layers.activeInventoryLayer.includes(l.name)}
               onClick={() => toggleInventoryLayer(l.name)}
             />

--- a/src/components/DataLayerSelector.tsx
+++ b/src/components/DataLayerSelector.tsx
@@ -43,7 +43,7 @@ const DataLayerDrawer: React.FC = () => {
         {layers.availableInventoryLayer.map((l) => (
           <IonItem lines="none" key={l.name}>
             <IonLabel>{l.title}</IonLabel>
-            <IonButton slot="start" fill="clear" disabled={!layers.activeInventoryLayer.includes(l.name)}>
+            <IonButton slot="start" fill="clear" disabled={!layers.activeInventoryLayer.includes(l.name)} onClick={() => layers.flyToFeature('inventory')}>
               <IonIcon icon={scanOutline} slot="icon-only" />
             </IonButton>
             <IonToggle

--- a/src/components/MainMapMaplibre.tsx
+++ b/src/components/MainMapMaplibre.tsx
@@ -7,6 +7,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import InventorySource from "./map-components/InventorySource";
 import BaseLayerSource from "./map-components/BaseLayerSource";
 import UserLocationSource from "./map-components/UserLocationSource";
+import LayerInteraction from "./map-components/LayerInteraction";
 const MainMap: React.FC = () => {
   // onload callback handler
   const onLoad = (e: any) => {
@@ -76,6 +77,7 @@ const MainMap: React.FC = () => {
       <InventorySource />
       <BaseLayerSource />
       <UserLocationSource />
+      <LayerInteraction />
     </Map>
   );
 };

--- a/src/components/map-components/LayerInteraction.tsx
+++ b/src/components/map-components/LayerInteraction.tsx
@@ -1,0 +1,7 @@
+const LayerInteraction: React.FC = () => {
+    return (
+        null
+    )
+}
+
+export default LayerInteraction

--- a/src/components/map-components/LayerInteraction.tsx
+++ b/src/components/map-components/LayerInteraction.tsx
@@ -1,4 +1,26 @@
+import { useEffect } from "react"
+import { useMap } from "react-map-gl"
+import { useData } from "../../context/data"
+import { useLayers } from "../../context/layers"
+
+// TODO: we can discuss if this should end up in the InventorySource component
 const LayerInteraction: React.FC = () => {
+    // get the layers
+    const { flyHandler } = useLayers()
+    const map = useMap()
+
+    const { filteredInventory } = useData()
+
+    // subscribe to fly events
+    useEffect(() => {
+        const subscription = flyHandler.subscribe(layerName => {
+            if (map.current && filteredInventory && filteredInventory!.bbox && layerName === 'inventory') {
+                map.current.fitBounds(filteredInventory.bbox as [number, number, number, number])
+            }
+        })
+        return () => subscription.unsubscribe()
+    }, [map, filteredInventory])
+
     return (
         null
     )

--- a/src/context/layers.tsx
+++ b/src/context/layers.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { useSettings } from "./settings";
+import { Subject } from "rxjs"
 
+import { useSettings } from "./settings";
 import * as wfs from '../util/wfs';
 import * as wms from '../util/wms';
 import { useOffline } from "./offline";
@@ -28,6 +29,7 @@ interface LayersState {
 
     // interactions with layers
     flyToFeature: (name: string) => void;
+    flyHandler: Subject<string>
 }
 
 // initial state
@@ -47,8 +49,8 @@ const initialState: LayersState = {
     setInventoryLayerTo: (layers: string[]) => {},
     setBaseLayerTo: (layers: string[]) => {},
     setDataLayerTo: (layers: string[]) => {},
-    flyToFeature: (name: string) => {}
-
+    flyToFeature: (name: string) => {},
+    flyHandler: new Subject()
 }
 
 // build the context
@@ -67,10 +69,11 @@ export const LayersProvider: React.FC<React.PropsWithChildren> = ({ children }) 
     const [availableDataLayer, setAvailableDataLayer] = useState<wfs.FeatureType[]>([])
     const [availableBaseLayer, setAvailableBaseLayer] = useState<wms.GroundLayerType[]>([])
 
-    
     // load available layers
     const { geoserverUrl } = useSettings()
     const { baselayers } = useOffline()
+
+    const [flyHandler, _] = useState<Subject<string>>(new Subject())
 
     // listen to changes in the offline context
     useEffect(() => {
@@ -158,6 +161,10 @@ export const LayersProvider: React.FC<React.PropsWithChildren> = ({ children }) 
         setActiveBaseLayer([...layers])
     }
 
+    const flyToFeature = (name: string) => {
+        flyHandler.next(name)
+    }
+
     // create the final value
     const value = {
         availableInventoryLayer,
@@ -175,7 +182,8 @@ export const LayersProvider: React.FC<React.PropsWithChildren> = ({ children }) 
         setInventoryLayerTo,
         setDataLayerTo,
         setBaseLayerTo,
-        flyToFeature: initialState.flyToFeature
+        flyToFeature,
+        flyHandler
     }
 
     return <>

--- a/src/context/layers.tsx
+++ b/src/context/layers.tsx
@@ -25,7 +25,9 @@ interface LayersState {
     setInventoryLayerTo: (layers: string[]) => void;
     setBaseLayerTo: (layers: string[]) => void;
     setDataLayerTo: (layers: string[]) => void;
-    
+
+    // interactions with layers
+    flyToFeature: (name: string) => void;
 }
 
 // initial state
@@ -44,7 +46,8 @@ const initialState: LayersState = {
     deactivateDataLayer: (layer: string) => {},
     setInventoryLayerTo: (layers: string[]) => {},
     setBaseLayerTo: (layers: string[]) => {},
-    setDataLayerTo: (layers: string[]) => {}
+    setDataLayerTo: (layers: string[]) => {},
+    flyToFeature: (name: string) => {}
 
 }
 
@@ -171,7 +174,8 @@ export const LayersProvider: React.FC<React.PropsWithChildren> = ({ children }) 
         deactivateBaseLayer,
         setInventoryLayerTo,
         setDataLayerTo,
-        setBaseLayerTo
+        setBaseLayerTo,
+        flyToFeature: initialState.flyToFeature
     }
 
     return <>


### PR DESCRIPTION
Adds a new component for handling reactive actions for map layers, that can be triggered *outside* of the map context (using rxjs).

Only merge after #28

This implements the the zoom-to-layer button

@JesJehle, we can discuss if we want this as a standalone component or add the logic directly into the InventorySource.