### PR TITLE
Fix-filter

### DIFF
--- a/src/components/RangeFilter.tsx
+++ b/src/components/RangeFilter.tsx
@@ -12,7 +12,6 @@ import {
 import React, { useEffect, useState } from "react";
 import { useData } from "../context/data";
 import { isEqual } from "lodash";
-import { react } from "plotly.js";
 
 interface RangeValue {
   lower: number;
@@ -27,18 +26,18 @@ const RangeFilter: React.FC = () => {
   const [radius, setRadius] = useState<RangeValue | undefined>(undefined);
   const [height, setHeight] = useState<RangeValue | undefined>(undefined);
 
-  // use effect to set the filter to current filter
   useEffect(() => {
-    // set default radius if still undefined
-    if (!radius && !!filterValues) {
-      setRadius({ ...filterValues.radius });
+    if (filterValues) {
+      setRadius({
+        lower: filterValues.radius.lower,
+        upper: filterValues.radius.upper,
+      })
+      setHeight({
+        lower: filterValues.height.lower,
+        upper: filterValues.height.upper,
+      })
     }
-
-    // set default height if still undefined
-    if (!height && !!filterValues) {
-      setHeight({ ...filterValues.height });
-    }
-  }, [inventoryStats, radius, height, filterValues]);
+  }, [filterValues])
 
   return (
     <IonList>
@@ -46,10 +45,7 @@ const RangeFilter: React.FC = () => {
         <IonLabel position="stacked">Height</IonLabel>
         <IonRange
           dualKnobs={true}
-          value={{
-            lower: height?.lower!,
-            upper: height?.upper!,
-          }}
+          value={height}
           pin={true}
           min={inventoryStats?.data?.heightMin as number}
           max={inventoryStats?.data?.heightMax as number}

--- a/src/components/popover/RangeFilterPopover.tsx
+++ b/src/components/popover/RangeFilterPopover.tsx
@@ -10,6 +10,7 @@ const FilterBarPopover: React.FC = () => {
       reference="trigger"
       side="bottom"
       arrow={true}
+      keepContentsMounted={true}
       // mode="md"
       showBackdrop={true}
       style={{


### PR DESCRIPTION
closes #71

@JesJehle, I tried *a lot* of different stuff, but noticed, that the range sliders are actually not disabled, but kind of *deselected* (compare to distance, which is actually deselected). This is really weird and I still don't get it.
If you add the `<RangeFilter />` to the inventory-list, it works perfectly, all the time. Thus, it was the component life-cycle of the **popover**. 

I changed the popover to never dismiss the components, thus the range-filter is now always mounted. A few quick tests indicate, that this was the problem. Thus, the error was caused by constantly creating and dismissing the component. With developer-tools enabled, this process was slowed down and *'fixed'* the issue. 
So, I think it works now, but I am not 100% sure why.