### PR TITLE
Selection map layer

### DIFF
--- a/src/components/InventoryList.tsx
+++ b/src/components/InventoryList.tsx
@@ -6,6 +6,7 @@ import {
   IonLabel,
   IonList,
   IonListHeader,
+  IonSpinner,
   IonThumbnail,
 } from "@ionic/react";
 import {
@@ -26,8 +27,12 @@ import { InventoryFeature } from "../context/data.model";
 
 import "./InventoryList.css";
 import { useSelection } from "../context/selection";
+import { useState } from "react";
 
 const InventoryList: React.FC = () => {
+  // add a state for processing selections
+  const [selectionProcessing, setSelectionProcessing] = useState<boolean>(false)
+
   // load the filtered inventory list
   const {
     filteredInventory,
@@ -84,14 +89,17 @@ const InventoryList: React.FC = () => {
     event: React.MouseEvent<HTMLIonButtonElement, MouseEvent>,
     treeId: number
   ) => {
+    // set selection processing
+    setSelectionProcessing(true)
+
     // stop event propagation
     event.stopPropagation();
 
     // check if this treeId is already in the selection
     if (activeSelection?.selection.treeIds.includes(treeId)) {
-      removeFromActiveSelection(treeId)
+      removeFromActiveSelection(treeId).finally(() => setSelectionProcessing(false))
     } else {
-      addToActiveSelection(treeId)
+      addToActiveSelection(treeId).finally(() => setSelectionProcessing(false))
     }
 
     //console.log("add to bookmarks");
@@ -162,9 +170,11 @@ const InventoryList: React.FC = () => {
               </IonLabel>
               <IonButton 
                 fill="clear" 
-                onClick={e => addToBookmarksHandler(e, f.properties.treeid)}
+                onClick={e => addToBookmarksHandler(e, Number(f.properties.treeid))}
               >
-                <IonIcon icon={activeSelection?.selection.treeIds.includes(f.properties.treeid) ? banOutline : bookmarkOutline}></IonIcon>
+                { selectionProcessing ? <IonSpinner name="lines" /> : (
+                  <IonIcon icon={activeSelection?.selection.treeIds.includes(Number(f.properties.treeid)) ? banOutline : bookmarkOutline} />
+                )}
               </IonButton>
             </IonItem>
           );

--- a/src/components/map-components/InventorySource.tsx
+++ b/src/components/map-components/InventorySource.tsx
@@ -6,18 +6,8 @@ import { Source, Layer, useMap } from "react-map-gl";
 import { useData } from "../../context/data";
 import { InventoryData, InventoryFeature } from "../../context/data.model";
 import { useLayers } from "../../context/layers";
-import {
-  IonCard,
-  IonCardContent,
-  IonCardHeader,
-  IonCardTitle,
-  IonItem,
-  IonLabel,
-  IonPopover,
-} from "@ionic/react";
 import { useHistory } from "react-router";
 import { useOffline } from "../../context/offline";
-import bbox from "@turf/bbox";
 
 const InventoryLayer: React.FC = () => {
   const {

--- a/src/components/map-components/MainMapMaplibre.tsx
+++ b/src/components/map-components/MainMapMaplibre.tsx
@@ -8,6 +8,7 @@ import InventorySource from "./InventorySource";
 import BaseLayerSource from "./BaseLayerSource";
 import UserLocationSource from "./UserLocationSource";
 import LayerInteraction from "./LayerInteraction";
+import SelectionSource from "./SelectionSource";
 
 const MainMap: React.FC = () => {
   // onload callback handler
@@ -75,6 +76,7 @@ const MainMap: React.FC = () => {
     >
       <InventorySource />
       <BaseLayerSource />
+      <SelectionSource />
       <UserLocationSource />
       <LayerInteraction />
     </Map>

--- a/src/components/map-components/SelectionSource.tsx
+++ b/src/components/map-components/SelectionSource.tsx
@@ -1,0 +1,47 @@
+import cloneDeep from "lodash.clonedeep"
+import { useEffect, useState } from "react"
+import { Layer, Source } from "react-map-gl"
+import { InventoryData } from "../../context/data.model"
+import { useSelection } from "../../context/selection"
+
+const SelectionSource: React.FC = () => {
+    // define a component state for the selection GeoJSON
+    const [src, setSrc] = useState<InventoryData | undefined>()
+
+    // subscribe to the current active selection
+    const { activeSelection } = useSelection()
+
+    // update component state when activeSelection changes
+    useEffect(() => {
+        if (activeSelection) {
+            console.log(activeSelection)
+            setSrc(cloneDeep(activeSelection.geoJSON))
+        } else {
+            setSrc(undefined)
+        }
+    }, [activeSelection])
+
+    // if there is no source, return null
+    console.log(src)
+    if (!src) {
+        return (
+            null
+        )
+    } else {
+        return (
+            <Source id="selection" type="geojson" data={src}>
+                <Layer 
+                    id="selection"
+                    source="selection"
+                    type="circle"
+                    paint={{
+                        "circle-radius": 10,
+                        "circle-color": "yellow"
+                    }}
+                />
+            </Source>
+        )
+    }
+}
+
+export default SelectionSource

--- a/src/components/map-components/SelectionSource.tsx
+++ b/src/components/map-components/SelectionSource.tsx
@@ -14,7 +14,6 @@ const SelectionSource: React.FC = () => {
     // update component state when activeSelection changes
     useEffect(() => {
         if (activeSelection) {
-            console.log(activeSelection)
             setSrc(cloneDeep(activeSelection.geoJSON))
         } else {
             setSrc(undefined)
@@ -22,7 +21,6 @@ const SelectionSource: React.FC = () => {
     }, [activeSelection])
 
     // if there is no source, return null
-    console.log(src)
     if (!src) {
         return (
             null


### PR DESCRIPTION
@JesJehle this PR makes current selections visible in the map.

I added the context to handle selections, and wired up the bookmark icons in the `InventoryList`. As soon as there is a selection and it is active, the selection will be visualized on the map by yellow circles. 

Please note, that no selection state management is implemented yet. You cannot manually activate and deactivate selections (although they persist through sessions). You can only delete selection altogether on the settings page.

Please review the Inventory list and the use of icons there and especially the implementation for the map layer. Right now, it's a completely new `<Source>` and `<Layer>`, which was straightforward to implement, but looks really, really ugly for visualization.

Should we implement the selection visualization into the existing `<InventorySource>`? What do you think?